### PR TITLE
docker compose buildのCIの実行条件を追加

### DIFF
--- a/.github/workflows/docker-compose-build.yaml
+++ b/.github/workflows/docker-compose-build.yaml
@@ -2,6 +2,9 @@ name: Docker Compose build
 
 on:
   pull_request:
+    paths:
+      - "docker/**"
+      - "compose.yaml"
 
 jobs:
   test:


### PR DESCRIPTION
docker compose buildのCIの実行条件を追加。

将来的にイメージが増えて時間が掛かる見込みなので，変更があった時だけビルドを実行する。