### PR TITLE
EPGStationのコンテナにタイムゾーンを指定

### DIFF
--- a/docker/epgstation/Dockerfile
+++ b/docker/epgstation/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && \
     && \
     make -j$(nproc) && \
     make install && \
-\
+# timezone
+    apt-get install -y tzdata && \
 # Cleanup
     apt-get -y remove $DEV && \
     apt-get autoremove -y && \


### PR DESCRIPTION
EPGStationのコンテナにタイムゾーンを指定。
TZ環境変数を指定するだけだと適用されないのでtzdataをインストールする