### PR TITLE
EPGStationのdepends_onからMirakurunを削除

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -79,7 +79,6 @@ services:
     environment:
       TZ: "Asia/Tokyo"
     depends_on:
-      - mirakurun
       - mysql
     restart: always
     logging:


### PR DESCRIPTION
Mirakurunをeq12-01からraspi-4b-01で動かすようにした。
eq12-01でEPGStationを動かす時にMirakurunを待機する必要がなくなったので，EPGStationのdepends_onからMirakurunを削除。